### PR TITLE
[OA-909] Add average latency to interval monitor

### DIFF
--- a/src/com/oltpbenchmark/ThreadBench.java
+++ b/src/com/oltpbenchmark/ThreadBench.java
@@ -268,13 +268,19 @@ public class ThreadBench implements Thread.UncaughtExceptionHandler {
                     return;
                 // Compute the last throughput
                 long measuredRequests = 0;
+                long measuredLatencies = 0;
                 synchronized (testState) {
                     for (Worker w : workers) {
-                        measuredRequests += w.getAndResetIntervalRequests();
+                        measuredLatencies += w.getIntervalLatenciesAverage();
+                        measuredRequests += w.getIntervalRequests();
+                        w.resetIntervalLatencies();
+                        w.resetIntervalRequests();
                     }
                 }
                 double tps = (double) measuredRequests / (double) this.intervalMonitor;
+                double latencyAve = ((double) measuredLatencies / (double) workers.size()) / 1000.0;
                 LOG.info("Throughput: " + tps + " Tps");
+                LOG.info("Latency Average: " + latencyAve + " ms");
             } // WHILE
         }
     } // CLASS


### PR DESCRIPTION
Add the ability to obtain TPS and average latency to the oltpbench interval monitor "-im <seconds>" command line switch.  This allows monitors to obtain metrics while the test is running, instead of waiting for the end of the test.
